### PR TITLE
[Fix] Adjust form input width for better screen resolution support

### DIFF
--- a/assets/static/index.html
+++ b/assets/static/index.html
@@ -54,7 +54,7 @@
             <form id="searchForm" class="mb-4" action="?" method="post">
                 <div class="input-group">
                     <input type="text" name="query" class="form-control flex-grow-1" id="speechInput" value="">
-                    <input type="number" name="limit" class="form-control text-center" id="limit" value="5" size="3" style="width: 5ch; flex: none;">
+                    <input type="number" name="limit" class="form-control text-center" id="limit" value="5" size="3" style="width: 8ch; flex: none;">
                     <button type="submit" class="btn btn-secondary"><i class="bi bi-search"></i></button>
                 </div>
             </form>


### PR DESCRIPTION
The form input width was too narrow, causing display issues on certain screen resolutions.
This fix increases the input width to improve usability and ensure proper display across various devices.

Changes:

Updated CSS to set a minimum width for the form input.

![Screenshot 2025-01-24 14 11 25](https://github.com/user-attachments/assets/5c206e64-5e9b-4134-a4d5-60885886c1e1)
